### PR TITLE
Fixed issue where onPlayerInteract() would re-enable cancelled event and removed duplicated enderchest check

### DIFF
--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameTuning.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameTuning.java
@@ -299,10 +299,11 @@ public class GameTuning extends SimpleHack<GameTuningConfig> implements Listener
 		if(!config.isEnabled() || !Action.RIGHT_CLICK_BLOCK.equals(event.getAction())) {
 			return;
 		}
-		boolean cancel = !config.isEnderChestInventories() && Material.ENDER_CHEST.equals(event.getClickedBlock().getType());
-		cancel |= !config.canChangeSpawnerType() && Material.SPAWNER.equals(event.getClickedBlock().getType())
+		boolean cancel = !config.canChangeSpawnerType() && Material.SPAWNER.equals(event.getClickedBlock().getType())
 				&& event.getItem() != null && event.getItem().getItemMeta() instanceof SpawnEggMeta;
-		event.setCancelled(cancel);
+		if (cancel) {
+			event.setCancelled(true);
+		}
 	}
 
 	@EventHandler


### PR DESCRIPTION
Calling `event.setCancelled(cancel);` with `cancel == false` re-enabling cancelled event. Since this handler was running on a higher priority than Citadel's, this would override `setCancelled(true)` performed by the latter. As referred in https://github.com/CivClassic/Citadel/pull/20, this would result in non-members being able to access chests, strip wood and tile grass into path.

This also remove the duplicated check for ender chests as it's done by another handler disableEnderChestUse() (https://github.com/CivClassic/SimpleAdminHacks/blob/civ14_2/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameFeatures.java#L272)