### PR TITLE
Added options for disabling Phantoms, Bad Omen and Patrols

### DIFF
--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/GameFeaturesConfig.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/GameFeaturesConfig.java
@@ -16,6 +16,7 @@ public class GameFeaturesConfig extends SimpleHackConfig {
 	private boolean villagerTrading;
 	private boolean witherSpawning;
 	private boolean patrolSpawning;
+	private boolean isPhantomSpawning;
 	private boolean enderChestPlacement;
 	private boolean enderChestUse;
 	private boolean shulkerBoxUse;
@@ -50,6 +51,9 @@ public class GameFeaturesConfig extends SimpleHackConfig {
 
 		this.patrolSpawning = config.getBoolean("patrolSpawning", false);
 		if (!this.patrolSpawning) plugin().log("Patrol Spawning is disabled");
+
+		this.patrolSpawning = config.getBoolean("phantomSpawning", false);
+		if (!this.patrolSpawning) plugin().log("Phantom Spawning is disabled");
 
 		this.enderChestPlacement = config.getBoolean("enderChestPlacement", true);
 		if (!this.enderChestPlacement) plugin().log("  Placing EnderChests is disabled");
@@ -110,7 +114,11 @@ public class GameFeaturesConfig extends SimpleHackConfig {
 	}
 
 	public boolean isPatrolSpawning() {
-		return this.isPatrolSpawning();
+		return this.patrolSpawning;
+	}
+
+	public boolean isPhantomSpawning() {
+		return this.isPhantomSpawning;
 	}
 
 	public boolean isEnderChestPlacement() {

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/GameFeaturesConfig.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/GameFeaturesConfig.java
@@ -15,6 +15,7 @@ public class GameFeaturesConfig extends SimpleHackConfig {
 	private boolean potatoXPEnabled;
 	private boolean villagerTrading;
 	private boolean witherSpawning;
+	private boolean patrolSpawning;
 	private boolean enderChestPlacement;
 	private boolean enderChestUse;
 	private boolean shulkerBoxUse;
@@ -46,6 +47,9 @@ public class GameFeaturesConfig extends SimpleHackConfig {
 
 		this.witherSpawning = config.getBoolean("witherSpawning", false);
 		if (!this.witherSpawning) plugin().log("  Wither Spawning is disabled");
+
+		this.patrolSpawning = config.getBoolean("patrolSpawning", false);
+		if (!this.patrolSpawning) plugin().log("Patrol Spawning is disabled");
 
 		this.enderChestPlacement = config.getBoolean("enderChestPlacement", true);
 		if (!this.enderChestPlacement) plugin().log("  Placing EnderChests is disabled");
@@ -103,6 +107,10 @@ public class GameFeaturesConfig extends SimpleHackConfig {
 
 	public boolean isWitherSpawning() {
 		return this.witherSpawning;
+	}
+
+	public boolean isPatrolSpawning() {
+		return this.isPatrolSpawning();
 	}
 
 	public boolean isEnderChestPlacement() {

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/GameFeaturesConfig.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/GameFeaturesConfig.java
@@ -52,8 +52,8 @@ public class GameFeaturesConfig extends SimpleHackConfig {
 		this.patrolSpawning = config.getBoolean("patrolSpawning", false);
 		if (!this.patrolSpawning) plugin().log("Patrol Spawning is disabled");
 
-		this.patrolSpawning = config.getBoolean("phantomSpawning", false);
-		if (!this.patrolSpawning) plugin().log("Phantom Spawning is disabled");
+		this.isPhantomSpawning = config.getBoolean("phantomSpawning", false);
+		if (!this.isPhantomSpawning) plugin().log("Phantom Spawning is disabled");
 
 		this.enderChestPlacement = config.getBoolean("enderChestPlacement", true);
 		if (!this.enderChestPlacement) plugin().log("  Placing EnderChests is disabled");

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/GameTuningConfig.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/GameTuningConfig.java
@@ -53,6 +53,8 @@ public class GameTuningConfig extends SimpleHackConfig {
 
 	private boolean preventFallingThroughBedrock;
 
+	private boolean badOmen;
+
 	private Set<Material> noPlace;
 
 	public GameTuningConfig(SimpleAdminHacks plugin, ConfigurationSection base) {
@@ -107,6 +109,9 @@ public class GameTuningConfig extends SimpleHackConfig {
 		if (!dragonGrief) plugin().log("Dragon grief is disabled.");
 
 		this.preventFallingThroughBedrock = config.getBoolean("preventFallingThroughBedrock", true);
+
+		this.badOmen = config.getBoolean("badOmen", false);
+		if (!badOmen) plugin().log("Bad Omen effect is disabled.");
 
 		noPlace = new HashSet<>();
 		if(config.isList("noplace")) {
@@ -299,6 +304,10 @@ public class GameTuningConfig extends SimpleHackConfig {
 
 	public boolean isPreventFallingThroughBedrock() {
 		return preventFallingThroughBedrock;
+	}
+
+	public boolean isBadOmenEnabled() {
+		return badOmen;
 	}
 
 	public boolean canPlace(Material mat) {

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameFeatures.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameFeatures.java
@@ -128,6 +128,13 @@ public class GameFeatures extends SimpleHack<GameFeaturesConfig> implements List
 				genStatus.append("disabled\n");
 			}
 
+			genStatus.append("  Patrol Spawning is ");
+			if (config.isPatrolSpawning()) {
+				genStatus.append("enabled\n");
+			} else {
+				genStatus.append("disabled\n");
+			}
+
 			genStatus.append("  Ender Chest placement is ");
 			if (config.isEnderChestPlacement()) {
 				genStatus.append("enabled\n");
@@ -257,6 +264,17 @@ public class GameFeatures extends SimpleHack<GameFeaturesConfig> implements List
 			}
 		}
 	}
+
+	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+	public void disablePatrols(CreatureSpawnEvent event) {
+		if (!config.isEnabled()) return;
+		if (!config.isPatrolSpawning()) {
+			if (event.getSpawnReason() == CreatureSpawnEvent.SpawnReason.PATROL) {
+				event.setCancelled(true);
+			}
+		}
+	}
+
 
 	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
 	public void disableEnderChestPlacement(BlockPlaceEvent event) {

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameFeatures.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameFeatures.java
@@ -135,6 +135,13 @@ public class GameFeatures extends SimpleHack<GameFeaturesConfig> implements List
 				genStatus.append("disabled\n");
 			}
 
+			genStatus.append("  Phantom Spawning is ");
+			if (config.isPhantomSpawning()) {
+				genStatus.append("enabled\n");
+			} else {
+				genStatus.append("disabled\n");
+			}
+
 			genStatus.append("  Ender Chest placement is ");
 			if (config.isEnderChestPlacement()) {
 				genStatus.append("enabled\n");
@@ -275,6 +282,16 @@ public class GameFeatures extends SimpleHack<GameFeaturesConfig> implements List
 		}
 	}
 
+	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+	public void disablePhantomSpawning(CreatureSpawnEvent event) {
+		if (!config.isEnabled()) return;
+		if (!config.isPhantomSpawning()) {
+			if (EntityType.PHANTOM.equals(event.getEntityType())
+					&& event.getSpawnReason() == CreatureSpawnEvent.SpawnReason.NATURAL) {
+				event.setCancelled(true);
+			}
+		}
+	}
 
 	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
 	public void disableEnderChestPlacement(BlockPlaceEvent event) {

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameTuning.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameTuning.java
@@ -25,10 +25,7 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.block.BlockPistonExtendEvent;
 import org.bukkit.event.block.BlockPistonRetractEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
-import org.bukkit.event.entity.EntityChangeBlockEvent;
-import org.bukkit.event.entity.EntityExplodeEvent;
-import org.bukkit.event.entity.EntityPortalEvent;
-import org.bukkit.event.entity.EntityTargetEvent;
+import org.bukkit.event.entity.*;
 import org.bukkit.event.inventory.InventoryMoveItemEvent;
 import org.bukkit.event.player.PlayerBedEnterEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
@@ -45,6 +42,8 @@ import com.programmerdan.minecraft.simpleadminhacks.SimpleAdminHacks;
 import com.programmerdan.minecraft.simpleadminhacks.SimpleHack;
 import com.programmerdan.minecraft.simpleadminhacks.configs.GameTuningConfig;
 import com.programmerdan.minecraft.simpleadminhacks.util.TeleportUtil;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
 
 /**
  * This is a grab-bag class to hold any _tuning_ related configurations that impact the
@@ -357,6 +356,18 @@ public class GameTuning extends SimpleHack<GameTuningConfig> implements Listener
 		if(config.isEnabled() && config.isPreventFallingThroughBedrock() && event.getTo().getY() < 1
 				&& GameMode.SURVIVAL.equals(event.getPlayer().getGameMode())) {
 			TeleportUtil.tryToTeleportVertically(event.getPlayer(), event.getTo(), "falling into the void");
+		}
+	}
+
+
+	@EventHandler
+	public void onBadOmenEffect(EntityPotionEffectEvent event) {
+		if (!config.isEnabled() || config.isBadOmenEnabled()) {
+			return;
+		}
+		PotionEffect effect = event.getNewEffect();
+		if (effect != null && effect.getType().equals(PotionEffectType.BAD_OMEN)) {
+			event.setCancelled(true);
 		}
 	}
 }

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameTuning.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameTuning.java
@@ -125,7 +125,63 @@ public class GameTuning extends SimpleHack<GameTuningConfig> implements Listener
 			} else {
 				genStatus.append("disabled\n");
 			}
-			// more?
+
+			genStatus.append("  Kill trap horses is ");
+			if (config.killTrapHorses()) {
+				genStatus.append("enabled\n");
+			} else {
+				genStatus.append("disabled\n");
+			}
+
+			genStatus.append("  Changing spawner type is ");
+			if (config.canChangeSpawnerType()) {
+				genStatus.append("enabled\n");
+			} else {
+				genStatus.append("disabled\n");
+			}
+
+			genStatus.append("  Villager trading is ");
+			if (config.allowVillagerTrading()) {
+				genStatus.append("enabled\n");
+			} else {
+				genStatus.append("disabled\n");
+			}
+
+			genStatus.append("  Ender grief is ");
+			if (config.isEnderGrief()) {
+				genStatus.append("enabled\n");
+			} else {
+				genStatus.append("disabled\n");
+			}
+
+			genStatus.append("  Wither grief is ");
+			if (config.isWitherGrief()) {
+				genStatus.append("enabled\n");
+			} else {
+				genStatus.append("disabled\n");
+			}
+
+			genStatus.append("  Dragon grief is ");
+			if (config.isDragonGrief()) {
+				genStatus.append("enabled\n");
+			} else {
+				genStatus.append("disabled\n");
+			}
+
+			genStatus.append("  Prevent falling through bedrock is ");
+			if (config.isPreventFallingThroughBedrock()) {
+				genStatus.append("enabled\n");
+			} else {
+				genStatus.append("disabled\n");
+			}
+
+			genStatus.append("  Bad Omen is ");
+			if (config.isBadOmenEnabled()) {
+				genStatus.append("enabled\n");
+			} else {
+				genStatus.append("disabled\n");
+			}
+
 		} else {
 			genStatus.append("inactive");
 		}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -23,6 +23,8 @@ hacks:
     # Prevent or allow pillager patrols from spawning
     # Patrols spawning is also true = enabled and false = disabled
     patrolSpawning: false
+    # Phantom spawn is also true = enabled and false = disabled
+    phantomSpawning: false
     # Enderchests is also true = enabled and false = disabled
     enderChestPlacement: true
     enderChestUse: false

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -86,6 +86,8 @@ hacks:
     dragonGrief: true
     allowEnchantedApples: false
     preventFallingThroughBedrock: true
+    # Disable the Bad Omen effect that player receive when killing pillager patrols
+    badOmen: false
     #a list of materials players shouldn't be allowed to place at all
     noplace:
      - DRAGON_EGG

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -20,6 +20,9 @@ hacks:
     villagerTrading: false
     # Wither spawn is also true = enabled and false = disabled
     witherSpawning: false
+    # Prevent or allow pillager patrols from spawning
+    # Patrols spawning is also true = enabled and false = disabled
+    patrolSpawning: false
     # Enderchests is also true = enabled and false = disabled
     enderChestPlacement: true
     enderChestUse: false


### PR DESCRIPTION
The Bad Omen and the Phantom options have been tested. I haven't been able to test if disabling Patrols worked because my test server has yet to spawn one. (I guess I'll see if I can force one to spawn). Bad Omen does not serve any purpose on a server without villages, it simply prevents potentials patrols from inflicting a 100 min effect on players.

By default, all three options are disabled.