### PR TITLE
Added option to disabled anchor bombing outside the nether

### DIFF
--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/GameFixesConfig.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/GameFixesConfig.java
@@ -9,7 +9,6 @@ import org.bukkit.configuration.ConfigurationSection;
 
 import com.programmerdan.minecraft.simpleadminhacks.SimpleAdminHacks;
 import com.programmerdan.minecraft.simpleadminhacks.SimpleHackConfig;
-import org.bukkit.event.EventHandler;
 
 public class GameFixesConfig extends SimpleHackConfig {
 

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/GameFixesConfig.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/GameFixesConfig.java
@@ -9,6 +9,7 @@ import org.bukkit.configuration.ConfigurationSection;
 
 import com.programmerdan.minecraft.simpleadminhacks.SimpleAdminHacks;
 import com.programmerdan.minecraft.simpleadminhacks.SimpleHackConfig;
+import org.bukkit.event.EventHandler;
 
 public class GameFixesConfig extends SimpleHackConfig {
 
@@ -19,6 +20,7 @@ public class GameFixesConfig extends SimpleHackConfig {
 	private boolean stopRailDupe;
 	private boolean stopEndPortalDeletion;
 	private boolean stopBedBombing;
+	private boolean stopAnchorBombing;
 
 	private ArrayList<BlockFace> bfArray;
 	private ArrayList<Material> railArray;
@@ -56,6 +58,9 @@ public class GameFixesConfig extends SimpleHackConfig {
 
 		stopBedBombing = config.getBoolean("stopBedBombingInHellBiomes", true);
 		if (stopBedBombing) plugin().log("  Stop Bed Bombing In Hell Biomes is enabled.");
+
+		stopAnchorBombing = config.getBoolean("stopAnchorBombing", true);
+		if (stopAnchorBombing) plugin().log("Stop Anchor bombing outside the Nether is enabled");
 
 		preventTreeWrap = config.getBoolean("preventTreeWraparound", true);
 		if (preventTreeWrap) plugin().log("  Stop tree wrapping into bedrock is enabled.");
@@ -149,6 +154,10 @@ public class GameFixesConfig extends SimpleHackConfig {
 
 	public boolean stopBedBombing() {
 		return this.stopBedBombing;
+	}
+
+	public boolean stopAnchorBombing() {
+		return this.stopAnchorBombing;
 	}
 
 	public boolean stopTreeWraparound() {

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameFixes.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameFixes.java
@@ -14,17 +14,13 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.data.type.Dispenser;
 import org.bukkit.block.data.type.Hopper;
+import org.bukkit.block.data.type.RespawnAnchor;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.event.block.BlockBreakEvent;
-import org.bukkit.event.block.BlockDispenseEvent;
-import org.bukkit.event.block.BlockFormEvent;
-import org.bukkit.event.block.BlockPistonExtendEvent;
-import org.bukkit.event.block.BlockPlaceEvent;
-import org.bukkit.event.block.SignChangeEvent;
+import org.bukkit.event.block.*;
 import org.bukkit.event.entity.EntityPortalEvent;
 import org.bukkit.event.entity.EntityTeleportEvent;
 import org.bukkit.event.inventory.InventoryMoveItemEvent;
@@ -304,6 +300,24 @@ public class GameFixes extends SimpleHack<GameFixesConfig> implements Listener {
 				|| Biome.END_BARRENS.equals(biome) || Biome.END_HIGHLANDS.equals(biome)
 				|| Biome.END_MIDLANDS.equals(biome) || Biome.SMALL_END_ISLANDS.equals(biome)
 				|| Biome.THE_END.equals(biome)) {
+			event.setCancelled(true);
+		}
+	}
+
+	@EventHandler(priority = EventPriority.NORMAL)
+	public void onAnchorInteraction(PlayerInteractEvent event) {
+		if (!config.isEnabled() || !config.stopAnchorBombing()) {
+			return;
+		}
+		if (!event.getClickedBlock().getType().equals(Material.RESPAWN_ANCHOR)) {
+			return;
+		}
+		RespawnAnchor anchor = (RespawnAnchor)event.getClickedBlock().getBlockData();
+		if (!event.getMaterial().equals(Material.GLOWSTONE)) {
+			plugin().getLogger().info("Material is glowstone");
+			event.setCancelled(true);
+		} else if (anchor.getCharges() == anchor.getMaximumCharges()) {
+			plugin().getLogger().info("Fully charged");
 			event.setCancelled(true);
 		}
 	}

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameFixes.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameFixes.java
@@ -314,10 +314,8 @@ public class GameFixes extends SimpleHack<GameFixesConfig> implements Listener {
 		}
 		RespawnAnchor anchor = (RespawnAnchor)event.getClickedBlock().getBlockData();
 		if (!event.getMaterial().equals(Material.GLOWSTONE)) {
-			plugin().getLogger().info("Material is glowstone");
 			event.setCancelled(true);
 		} else if (anchor.getCharges() == anchor.getMaximumCharges()) {
-			plugin().getLogger().info("Fully charged");
 			event.setCancelled(true);
 		}
 	}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -51,6 +51,7 @@ hacks:
     stopRailDupe: true
     stopEndPortalDeletion: true
     stopBedBombingInHellBiomes: true
+    stopAnchorBombing: true
     preventTreeWraparound: true
     fixPearlGlitch: true
   GameTuning:


### PR DESCRIPTION
Like beds in the nether, [Respawn Anchor](https://minecraft.gamepedia.com/Respawn_Anchor) blow up when used in the overworld.
This prevents them from exploding but still allow player to charge them with glowstone (aesthetics purpose).

Explosions are blocked by default.
