### PR TITLE
Check horse stats with item

### DIFF
--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/HorseStatsConfig.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/HorseStatsConfig.java
@@ -1,0 +1,18 @@
+package com.programmerdan.minecraft.simpleadminhacks.configs;
+
+import com.programmerdan.minecraft.simpleadminhacks.SimpleAdminHacks;
+import com.programmerdan.minecraft.simpleadminhacks.SimpleHackConfig;
+import org.bukkit.configuration.ConfigurationSection;
+
+public class HorseStatsConfig extends SimpleHackConfig {
+
+
+	public HorseStatsConfig(SimpleAdminHacks plugin, ConfigurationSection base) {
+		super(plugin, base);
+	}
+
+	@Override
+	protected void wireup(ConfigurationSection config) {
+
+	}
+}

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/HorseStatsConfig.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/HorseStatsConfig.java
@@ -2,10 +2,12 @@ package com.programmerdan.minecraft.simpleadminhacks.configs;
 
 import com.programmerdan.minecraft.simpleadminhacks.SimpleAdminHacks;
 import com.programmerdan.minecraft.simpleadminhacks.SimpleHackConfig;
+import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
 
 public class HorseStatsConfig extends SimpleHackConfig {
 
+	private Material horseCheckerItem;
 
 	public HorseStatsConfig(SimpleAdminHacks plugin, ConfigurationSection base) {
 		super(plugin, base);
@@ -13,6 +15,10 @@ public class HorseStatsConfig extends SimpleHackConfig {
 
 	@Override
 	protected void wireup(ConfigurationSection config) {
+		horseCheckerItem = Material.getMaterial(config.getString("wand"));
+	}
 
+	public Material getHorseCheckerItem() {
+		return horseCheckerItem;
 	}
 }

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/HorseStats.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/HorseStats.java
@@ -23,18 +23,15 @@ public class HorseStats extends SimpleHack<HorseStatsConfig> implements Listener
 
 	public HorseStats(SimpleAdminHacks plugin, HorseStatsConfig config) {
 		super(plugin, config);
-		plugin().log("Instanciating HS");
 	}
 
 	@EventHandler(priority = EventPriority.NORMAL)
 	public void onHorseStatCheck(PlayerInteractEntityEvent event) {
-		plugin().log("Active");
 		if (!config.isEnabled()) {
 			return;
 		}
-		plugin().log("Enabled");
 		ItemStack item = event.getPlayer().getInventory().getItemInMainHand();
-		if (item.getType() != Material.COMPASS) {
+		if (!item.getType().equals(config.getHorseCheckerItem())) {
 			return;
 		}
 		Entity entity = event.getRightClicked();

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/HorseStats.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/HorseStats.java
@@ -1,0 +1,95 @@
+package com.programmerdan.minecraft.simpleadminhacks.hacks;
+
+import com.programmerdan.minecraft.simpleadminhacks.SimpleAdminHacks;
+import com.programmerdan.minecraft.simpleadminhacks.SimpleHack;
+import com.programmerdan.minecraft.simpleadminhacks.configs.HorseStatsConfig;
+import com.programmerdan.minecraft.simpleadminhacks.configs.ToggleLampConfig;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.AbstractHorse;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Horse;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.inventory.ItemStack;
+import vg.civcraft.mc.citadel.Citadel;
+
+public class HorseStats extends SimpleHack<HorseStatsConfig> implements Listener {
+
+	public HorseStats(SimpleAdminHacks plugin, HorseStatsConfig config) {
+		super(plugin, config);
+		plugin().log("Instanciating HS");
+	}
+
+	@EventHandler(priority = EventPriority.NORMAL)
+	public void onHorseStatCheck(PlayerInteractEntityEvent event) {
+		plugin().log("Active");
+		if (!config.isEnabled()) {
+			return;
+		}
+		plugin().log("Enabled");
+		ItemStack item = event.getPlayer().getInventory().getItemInMainHand();
+		if (item.getType() != Material.COMPASS) {
+			return;
+		}
+		Entity entity = event.getRightClicked();
+		if (!(entity instanceof AbstractHorse)) {
+			return;
+		}
+		AbstractHorse horse = (AbstractHorse)entity;
+		AttributeInstance attrHealth = horse.getAttribute(Attribute.GENERIC_MAX_HEALTH);
+		AttributeInstance attrSpeed = horse.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED);
+		event.getPlayer().sendMessage(String.format("%sHealth = %f, Speed = %f, Jump height = %f",
+				ChatColor.YELLOW,
+				attrHealth.getBaseValue(),
+				attrSpeed.getBaseValue(),
+				horse.getJumpStrength()));
+	}
+
+	@Override
+	public void registerListeners() {
+		if (config.isEnabled()) {
+			plugin().log("Registering HorseStats listeners");
+			plugin().registerListener(this);
+		}
+	}
+
+	@Override
+	public void registerCommands() {
+
+	}
+
+	@Override
+	public void dataBootstrap() {
+
+	}
+
+	@Override
+	public void unregisterListeners() {
+
+	}
+
+	@Override
+	public void unregisterCommands() {
+
+	}
+
+	@Override
+	public void dataCleanup() {
+
+	}
+
+	public static HorseStatsConfig generate(SimpleAdminHacks plugin, ConfigurationSection config) {
+		return new HorseStatsConfig(plugin, config);
+	}
+
+	@Override
+	public String status() {
+		return config.isEnabled() ? "HorseStats enabled." : "HorseStats disabled.";
+	}
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -237,6 +237,9 @@ hacks:
   ToggleLamp:
     enabled: false
     cooldownTime: 100
+  HorseStats:
+    enabled: false
+    wand: COMPASS
   AutoRespawn:
     enabled: true
     # Delay in MS


### PR DESCRIPTION
Added module to let Player check Horse statistics by right clicking on them using a given item (a compass by default)
This would lessen the need for mods for this purpose.

Note: The values that are displayed are the base values and are unaffected by potion effects.