### PR TITLE
Add support for condensing mobs and merge all portal-spawned mobs into a single type.

### DIFF
--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/MobCondenser.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/MobCondenser.java
@@ -1,0 +1,62 @@
+package com.programmerdan.minecraft.simpleadminhacks.hacks.basic;
+
+import com.programmerdan.minecraft.simpleadminhacks.SimpleAdminHacks;
+import com.programmerdan.minecraft.simpleadminhacks.framework.BasicHack;
+import com.programmerdan.minecraft.simpleadminhacks.framework.BasicHackConfig;
+import com.programmerdan.minecraft.simpleadminhacks.framework.autoload.AutoLoad;
+import com.programmerdan.minecraft.simpleadminhacks.framework.autoload.DataParser;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.EntityType;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.entity.CreatureSpawnEvent;
+import org.bukkit.event.entity.EntityDeathEvent;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+
+public class MobCondenser extends BasicHack
+{
+	private Random rng;
+
+	@AutoLoad
+	private double mobSpawnMultiplier;
+
+	@AutoLoad(processor = DataParser.ENTITY_TYPE)
+	private List<EntityType> types;
+
+	public MobCondenser(SimpleAdminHacks plugin, BasicHackConfig config)
+	{
+		super(plugin, config);
+		rng = new Random();
+	}
+
+	private boolean roll(double chance) {
+		return rng.nextDouble() <= chance;
+	}
+
+	@EventHandler(priority = EventPriority.LOW) //Run before the PortalSpawnModifier
+	public void onCreatureSpawn(CreatureSpawnEvent e) {
+		if (types.contains(e.getEntityType())) {
+			if (!roll(mobSpawnMultiplier)) {
+				e.setCancelled(true);
+				return;
+			}
+		}
+	}
+
+	@EventHandler(priority = EventPriority.HIGH) //Run after PortalSpawnModifier
+	public void onEntityDeath(EntityDeathEvent e) {
+		if (types.contains(e.getEntityType())) {
+			Iterator<ItemStack> iterator = e.getDrops().iterator();
+
+			while (iterator.hasNext()) {
+				ItemStack itemStack = iterator.next();
+				itemStack.setAmount((int) Math.round(itemStack.getAmount() / mobSpawnMultiplier));
+			}
+		}
+	}
+
+}

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/MobCondenser.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/MobCondenser.java
@@ -3,34 +3,62 @@ package com.programmerdan.minecraft.simpleadminhacks.hacks.basic;
 import com.programmerdan.minecraft.simpleadminhacks.SimpleAdminHacks;
 import com.programmerdan.minecraft.simpleadminhacks.framework.BasicHack;
 import com.programmerdan.minecraft.simpleadminhacks.framework.BasicHackConfig;
-import com.programmerdan.minecraft.simpleadminhacks.framework.autoload.AutoLoad;
-import com.programmerdan.minecraft.simpleadminhacks.framework.autoload.DataParser;
-import org.bukkit.Bukkit;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.inventory.ItemStack;
+import vg.civcraft.mc.civmodcore.entities.EntityUtils;
 
+import java.util.HashMap;
 import java.util.Iterator;
-import java.util.List;
+import java.util.Map;
 import java.util.Random;
 
 public class MobCondenser extends BasicHack
 {
 	private Random rng;
-
-	@AutoLoad
-	private double mobSpawnMultiplier;
-
-	@AutoLoad(processor = DataParser.ENTITY_TYPE)
-	private List<EntityType> types;
+	private Map<EntityType, Double> mobSpawnModifiers;
 
 	public MobCondenser(SimpleAdminHacks plugin, BasicHackConfig config)
 	{
 		super(plugin, config);
-		rng = new Random();
+		this.rng = new Random();
+		this.mobSpawnModifiers = new HashMap<>();
+	}
+
+	@Override
+	public void onEnable()
+	{
+		super.onEnable();
+
+		final ConfigurationSection base = this.config.getBase();
+		final ConfigurationSection spawnModifiers = base.getConfigurationSection("mobSpawnModifiers");
+		if (spawnModifiers != null) {
+			for (final String key : spawnModifiers.getKeys(false)) {
+				final EntityType type = EntityUtils.getEntityType(key);
+				if (type == null) {
+					this.plugin.warning("[" + getClass().getSimpleName() + "] EntityType: \"" + key + "\" does not exist, skipping.");
+					continue;
+				}
+				double modifier = spawnModifiers.getDouble(key, 1.0d);
+				if (modifier < 0.0d) {
+					this.plugin.warning("[" + getClass().getSimpleName() + "] Mob Spawn Modifier: \"" + modifier + "\" for \"" + key + "\" is unsupported, defaulting to 1.0");
+					modifier = 1.0d;
+				}
+				this.mobSpawnModifiers.put(type, modifier);
+			}
+		}
+	}
+
+	@Override
+	public void onDisable()
+	{
+		this.mobSpawnModifiers.clear();
+
+		super.onDisable();
 	}
 
 	private boolean roll(double chance) {
@@ -39,8 +67,8 @@ public class MobCondenser extends BasicHack
 
 	@EventHandler(priority = EventPriority.LOW) //Run before the PortalSpawnModifier
 	public void onCreatureSpawn(CreatureSpawnEvent e) {
-		if (types.contains(e.getEntityType())) {
-			if (!roll(mobSpawnMultiplier)) {
+		if (mobSpawnModifiers.containsKey(e.getEntityType())) {
+			if (!roll(mobSpawnModifiers.get(e.getEntityType()))) {
 				e.setCancelled(true);
 				return;
 			}
@@ -49,12 +77,12 @@ public class MobCondenser extends BasicHack
 
 	@EventHandler(priority = EventPriority.HIGH) //Run after PortalSpawnModifier
 	public void onEntityDeath(EntityDeathEvent e) {
-		if (types.contains(e.getEntityType())) {
+		if (mobSpawnModifiers.containsKey(e.getEntityType())) {
 			Iterator<ItemStack> iterator = e.getDrops().iterator();
 
 			while (iterator.hasNext()) {
 				ItemStack itemStack = iterator.next();
-				itemStack.setAmount((int) Math.round(itemStack.getAmount() / mobSpawnMultiplier));
+				itemStack.setAmount((int) Math.round(itemStack.getAmount() / mobSpawnModifiers.get(e.getEntityType())));
 			}
 		}
 	}

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/MobCondenser.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/MobCondenser.java
@@ -3,7 +3,9 @@ package com.programmerdan.minecraft.simpleadminhacks.hacks.basic;
 import com.programmerdan.minecraft.simpleadminhacks.SimpleAdminHacks;
 import com.programmerdan.minecraft.simpleadminhacks.framework.BasicHack;
 import com.programmerdan.minecraft.simpleadminhacks.framework.BasicHackConfig;
-import org.bukkit.Bukkit;
+import com.programmerdan.minecraft.simpleadminhacks.framework.autoload.AutoLoad;
+import com.programmerdan.minecraft.simpleadminhacks.framework.autoload.DataParser;
+import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
@@ -18,6 +20,7 @@ import vg.civcraft.mc.civmodcore.inventory.items.SpawnEggUtils;
 
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
@@ -25,6 +28,9 @@ public class MobCondenser extends BasicHack
 {
 	private Random rng;
 	private Map<EntityType, Double> mobSpawnModifiers;
+
+	@AutoLoad(processor = DataParser.MATERIAL)
+	private List<Material> materialModificationWhitelist;
 
 	public MobCondenser(SimpleAdminHacks plugin, BasicHackConfig config)
 	{
@@ -104,7 +110,9 @@ public class MobCondenser extends BasicHack
 
 			while (iterator.hasNext()) {
 				ItemStack itemStack = iterator.next();
-				itemStack.setAmount((int) Math.round(itemStack.getAmount() / mobSpawnModifiers.get(e.getEntityType())));
+				if (materialModificationWhitelist.contains(itemStack.getType())) {
+					itemStack.setAmount((int) Math.round(itemStack.getAmount() / mobSpawnModifiers.get(e.getEntityType())));
+				}
 			}
 		}
 	}

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/MobCondenser.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/MobCondenser.java
@@ -14,6 +14,7 @@ import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
 import vg.civcraft.mc.civmodcore.entities.EntityUtils;
+import vg.civcraft.mc.civmodcore.inventory.items.SpawnEggUtils;
 
 import java.util.HashMap;
 import java.util.Iterator;
@@ -84,7 +85,7 @@ public class MobCondenser extends BasicHack
 	public void onMobEggUse(PlayerInteractEvent e) {
 		if (e.getAction() == Action.RIGHT_CLICK_BLOCK && e.getItem() != null) {
 			try {
-				EntityType type = EntityType.valueOf(e.getItem().getType().toString().replace("_SPAWN_EGG", ""));
+				EntityType type = SpawnEggUtils.getEntityType(e.getItem().getType());
 
 				if (mobSpawnModifiers.containsKey(type)) {
 					if (!roll(mobSpawnModifiers.get(type))) {

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/MobCondenser.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/MobCondenser.java
@@ -49,6 +49,7 @@ public class MobCondenser extends BasicHack
 					modifier = 1.0d;
 				}
 				this.mobSpawnModifiers.put(type, modifier);
+				this.plugin.info("[" + getClass().getSimpleName() + "] Registered Mob Spawn Modifier: [" + type + ": " + modifier + "]");
 			}
 		}
 	}

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/MobCondenser.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/MobCondenser.java
@@ -7,6 +7,7 @@ import com.programmerdan.minecraft.simpleadminhacks.framework.autoload.AutoLoad;
 import com.programmerdan.minecraft.simpleadminhacks.framework.autoload.DataParser;
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.Ageable;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -82,6 +83,14 @@ public class MobCondenser extends BasicHack
 			if (!roll(mobSpawnModifiers.get(e.getEntityType()))) {
 				if (e.getSpawnReason() != CreatureSpawnEvent.SpawnReason.SPAWNER_EGG) {
 					e.setCancelled(true);
+				}
+				else if (e.getEntity() instanceof Ageable) // Is from a spawn egg, and is Ageable
+				{
+					Ageable ageable = (Ageable) e.getEntity();
+
+					if (!ageable.isAdult()) { //Only spawns from right clicking other mobs with a spawn egg
+						e.setCancelled(true);
+					}
 				}
 			}
 		}

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/MobCondenser.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/MobCondenser.java
@@ -3,12 +3,15 @@ package com.programmerdan.minecraft.simpleadminhacks.hacks.basic;
 import com.programmerdan.minecraft.simpleadminhacks.SimpleAdminHacks;
 import com.programmerdan.minecraft.simpleadminhacks.framework.BasicHack;
 import com.programmerdan.minecraft.simpleadminhacks.framework.BasicHackConfig;
+import org.bukkit.Bukkit;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
+import org.bukkit.event.block.Action;
 import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
 import vg.civcraft.mc.civmodcore.entities.EntityUtils;
 
@@ -70,9 +73,26 @@ public class MobCondenser extends BasicHack
 	public void onCreatureSpawn(CreatureSpawnEvent e) {
 		if (mobSpawnModifiers.containsKey(e.getEntityType())) {
 			if (!roll(mobSpawnModifiers.get(e.getEntityType()))) {
-				e.setCancelled(true);
-				return;
+				if (e.getSpawnReason() != CreatureSpawnEvent.SpawnReason.SPAWNER_EGG) {
+					e.setCancelled(true);
+				}
 			}
+		}
+	}
+
+	@EventHandler
+	public void onMobEggUse(PlayerInteractEvent e) {
+		if (e.getAction() == Action.RIGHT_CLICK_BLOCK && e.getItem() != null) {
+			try {
+				EntityType type = EntityType.valueOf(e.getItem().getType().toString().replace("_SPAWN_EGG", ""));
+
+				if (mobSpawnModifiers.containsKey(type)) {
+					if (!roll(mobSpawnModifiers.get(type))) {
+						e.setCancelled(true);
+						e.getItem().setAmount(e.getItem().getAmount() -1);
+					}
+				}
+			} catch (IllegalArgumentException ignored) {}
 		}
 	}
 

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/PortalSpawnModifier.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/basic/PortalSpawnModifier.java
@@ -11,6 +11,7 @@ import org.bukkit.Material;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.PigZombie;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.block.BlockDispenseArmorEvent;
 import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason;
 import org.bukkit.event.entity.EntityDeathEvent;
@@ -75,6 +76,13 @@ public class PortalSpawnModifier extends BasicHack {
 	public void onEntityPickupItem(EntityPickupItemEvent e) {
 		if (e.getEntityType() == EntityType.ZOMBIFIED_PIGLIN) {
 			e.setCancelled(true); // Prevents giving piglins items to change what they drop
+		}
+	}
+
+	@EventHandler
+	public void dispenseArmorEvent(BlockDispenseArmorEvent e) {
+		if (e.getTargetEntity().getType() == EntityType.ZOMBIFIED_PIGLIN) {
+			e.setCancelled(true);
 		}
 	}
 


### PR DESCRIPTION
Added support for Mob Condensing, where spawns of a mob are reduced by a factor, but items dropped by that type of mob are increased by the same factor.

Stopped spawning Wither Skeletons and Ghasts from Nether Portals to replace them with Zombified Piglin variants.

Wither Skeletons will now be Zombie Piglins wearing a Wither Skull as a hat, and Ghasts will be Zombie Piglins holding a Ghast Tear in their offhand.

There should be no changes to game balance, aside from a reduction in mob counts.

PortalSpawnModifer requires no config changes.
Mob Condenser requires a config in the following format:
MobCondenser:
  enabled: true
  mobSpawnModifiers:
    ZOMBIFIED_PIGLIN: 0.10

The mobSpawnModifiers controls the entity type, and the new spawn rate, so in the above example Zombified Piglins will spawn 10x less, but drop 10x the items.