### PR TITLE
Fix unintuitive gold block error messages

### DIFF
--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameFeatures.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameFeatures.java
@@ -560,7 +560,7 @@ public class GameFeatures extends SimpleHack<GameFeaturesConfig> implements List
 				return;
 			}
 		}
-		event.getPlayer().sendMessage(ChatColor.RED + "No gold block to teleport you to");
+		event.getPlayer().sendMessage(ChatColor.RED + "No gold block to teleport you up to. Sneak to teleport down instead.");
 	}
 
 	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
@@ -577,7 +577,7 @@ public class GameFeatures extends SimpleHack<GameFeaturesConfig> implements List
 				return;
 			}
 		}
-		event.getPlayer().sendMessage(ChatColor.RED + "No gold block to teleport you to");
+		event.getPlayer().sendMessage(ChatColor.RED + "No gold block to teleport you down to. Jump to teleport up instead.");
 	}
 
 	@EventHandler(priority = EventPriority.NORMAL)


### PR DESCRIPTION
These changes are to address the following:
1. The error messages don't say whether you tried to teleport up or down.
2. There's no indication how to proceed when encountering an error to someone who doesn't know how gold block TPs work.